### PR TITLE
Added from date to attendance.js

### DIFF
--- a/autocaptcha-for-chrome/attendance.js
+++ b/autocaptcha-for-chrome/attendance.js
@@ -7,4 +7,7 @@ function getDateString(date) {
 			date.getFullYear();
 }
 
+var dt = document.evaluate( '/html/body/table/tbody/tr/td[2]/table/tbody/tr[3]/td[3]/font', document, null, XPathResult.STRING_TYPE, null);
+
+document.getElementsByName("from_date")[0].value=dt.stringValue;
 document.getElementsByName("to_date")[0].value=getDateString(new Date());

--- a/autocaptcha-for-firefox/data/attendance.js
+++ b/autocaptcha-for-firefox/data/attendance.js
@@ -7,4 +7,7 @@ function getDateString(date) {
 			date.getFullYear();
 }
 
+var dt = document.evaluate( '/html/body/table/tbody/tr/td[2]/table/tbody/tr[3]/td[3]/font', document, null, XPathResult.STRING_TYPE, null);
+
+document.getElementsByName("from_date")[0].value=dt.stringValue;
 document.getElementsByName("to_date")[0].value=getDateString(new Date());


### PR DESCRIPTION
The term's start date now appears in the 'from_date' field of the attendance page.
